### PR TITLE
Scheduled job setup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     purrr,
     readr,
     readxl,
+    rjson,
     synapser (>= 0.11),
     tidyr
 Suggests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN install2.r --error \
     purrr \
     readr \
     readxl \
+    rjson \
     tidyr \
     log4r \
     mockery \
@@ -27,7 +28,7 @@ ADD https://api.github.com/repos/Sage-Bionetworks/cleanAD/git/refs/heads/master 
 
 RUN git clone https://github.com/Sage-Bionetworks/cleanAD.git && \
     chmod +x cleanAD/update_table.sh
-    
+
 RUN R CMD INSTALL ./cleanAD
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update --allow-releaseinfo-change && \
 ADD https://api.github.com/repos/Sage-Bionetworks/cleanAD/git/refs/heads/master version.json
 
 RUN git clone https://github.com/Sage-Bionetworks/cleanAD.git && \
-    chmod +x cleanAD/update_table.sh
+    chmod +x cleanAD/update_table.sh cleanAD_scheduled_job_update_table.sh
 
 RUN R CMD INSTALL ./cleanAD
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ cd cleanAD
 docker build -t cleanad .
 ```
 
+##### Running as a Scheduled Job in the Sage AWS Service Catalog
+
+Provide a Synapse PAT to the Scheduled Job secrets field named `"SYNAPSE_AUTH_TOKEN":"<your-PAT-here>"`.
+
+Pull the public docker image and run with the following command (`ad` and `TRUE` are arguments to `config` and `as_scheduled_job` respectively).
+
+```bash
+docker run --rm --entrypoint "./cleanAD/scheduled_job_update_table.sh" sagebionetworks/cleanad:latest ad TRUE
+```
+
+
+

--- a/scheduled_job_update_table.sh
+++ b/scheduled_job_update_table.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+Rscript cleanAD/inst/scripts/generate-table-ad.R --config $1 --as_scheduled_job $2


### PR DESCRIPTION
Add functionality to run as a scheduled job in service catalog:

- add option to run the generate-ad-table.R script with `--as_scheduled_job`
- change synLogin to look for a scheduled job secret if specified
- update readMe 